### PR TITLE
Add link to PkgButlerEngine.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The GitHub Action repository for the Julia Package Butler.
 
+The underlying functionality for `julia-pkgbutler` is provided by the [`PkgButlerEngine.jl` Julia package](https://github.com/davidanthoff/PkgButlerEngine.jl).
+
 ## Functionality
 
 The Julia Package Butler currently makes the following changes to a package repository:


### PR DESCRIPTION
The julia-pkgbutler README should link to PkgButlerEngine.jl, and vice-versa.

See also: https://github.com/davidanthoff/PkgButlerEngine.jl/pull/27